### PR TITLE
Low3 to Mid2

### DIFF
--- a/racs_backup.sh
+++ b/racs_backup.sh
@@ -60,7 +60,7 @@ DATA_DIR=${3:-"/askapbuffer/scott/askap-scheduling-blocks/${SBID}"}
 
 
 ## Load up appropriate modules
-module load rclone/1.62.2
+module load rclone/1.63.1
 
 ## Rclone config
 # Assuming the remote is called 'askap' 

--- a/racs_backup.sh
+++ b/racs_backup.sh
@@ -66,8 +66,8 @@ module load rclone/1.62.2
 # Assuming the remote is called 'askap' 
 #   - need to ensure this is in the rclone config
 # Here we're also locking in the bucket name to be 'RACSlow3-backup'
-BUCKET_NAME="racslow3-backup"
-REMOTE_NAME="askap"
+BUCKET_NAME="racsmid2-backup"
+REMOTE_NAME="askaprt"
 
 
 ## Ensure bucket exists


### PR DESCRIPTION
In order to support racs-mid2, this backup script is being updated to:
- replace low3 with mid2
- updating the rclone profile from askap to askaprt

The module version of rclone loaded has also been updated to match what is currently offered by pawsey